### PR TITLE
スマホ対応＆ページ下部のGooooooooogleがoooooooooになっていた不具合を修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "個人情報非表示 in google.co.jp",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "manifest_version": 3,
     "description": "google.co.jpの検索ページに存在する住所の表示を削除します。\nすべてのページで正しく動作する保証はありません。",
     "content_scripts": [

--- a/replace.css
+++ b/replace.css
@@ -3,8 +3,7 @@
 #fbar > div > div:where(:nth-child(2)),
 .b2hzT,
 /** 検索結果上部に表示される住所 */
-dynamic-visibility-control > div > div > div > div:first-child > span > :nth-child(3 of span),
-.BBwThe {
+dynamic-visibility-control > div > div > div > div:first-child > span > :nth-child(3 of span) {
   display: none !important;
 }
 

--- a/replace.css
+++ b/replace.css
@@ -3,14 +3,27 @@
 #fbar > div > div:where(:nth-child(2)),
 .b2hzT,
 /** 検索結果上部に表示される住所 */
-dynamic-visibility-control > div > div > div > div:first-child > span > :nth-child(3 of span) {
+dynamic-visibility-control > div > div > div > div:first-child > span > :nth-child(3 of span),
+/* スマホ版表示のページ下部の住所 */
+#swml div > div > a > div {
   display: none !important;
 }
 
 
 dynamic-visibility-control > div > div > div > div:first-child > span::after,
-:is(.eKPi4, .BUSxSd) > span::after {
+:is(.eKPi4, .BUSxSd) > span::after,
+/* スマホ版表示のページ下部の住所 */
+#swml div > div > a::after {
   content: "個人情報の為非表示" !important;
   /* display: block !important; */
   max-width: auto !important;
+}
+
+/* スマホ版表示の住所の詳細表示ボタン */
+dynamic-visibility-control > div > div > div > :is(div:nth-child(3), .R0cdZ),
+/* スマホ版表示のフッター */
+#swml div > div > a {
+  /* クリックしても反応しないようにする */
+  pointer-events: none !important;
+  cursor: default !important; 
 }


### PR DESCRIPTION
## 変更内容
- スマホ版表示のGoogle検索にて個人情報が非表示になるように変更
- ページ下部のページネーション（Gooooooooogle）の表示が壊れていた不具合を修正

## 修正前

<img width="416" height="122" alt="image" src="https://github.com/user-attachments/assets/71bafa05-5968-457a-97de-fadf8dcda87c" />

## 修正後

<img width="460" height="139" alt="image" src="https://github.com/user-attachments/assets/1553d8d4-0d9a-4067-b608-0df3d4947cef" />
